### PR TITLE
ci: run "apt-get update" before installing packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
 
     - name: Install apt dependencies
       run: |
+        sudo apt-get update && \
         sudo apt-get install -y --no-install-recommends \
           dblatex \
           docbook-xml \


### PR DESCRIPTION
We've gotten the following error in [fix: doc/index.txt: correct links (#6) · asciidoc-py/asciidoc-py.github.io@90b1c21](https://github.com/asciidoc-py/asciidoc-py.github.io/runs/5706547931?check_suite_focus=true#step:4:180):

```
Err:82 http://security.ubuntu.com/ubuntu focal-updates/main amd64 libxml2-utils amd64 2.9.10+dfsg-5ubuntu0.20.04.1
  404  Not Found [IP: 52.154.174.208 80]
...
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.10+dfsg-5ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

I think an `apt-get update` may solve this issue.